### PR TITLE
Simpler, better redo of InstallESD.dmg support for #2 and #7.

### DIFF
--- a/AutoDMG/IEDSourceSelector.py
+++ b/AutoDMG/IEDSourceSelector.py
@@ -33,7 +33,8 @@ def checkSource_(self, sender):
     filenames = pboard.propertyListForType_(NSFilenamesPboardType)
     if len(filenames) == 1:
         if os.path.exists(os.path.join(filenames[0],
-                          u"Contents/SharedSupport/InstallESD.dmg")):
+                          u"Contents/SharedSupport/InstallESD.dmg")) or \
+        os.path.basename(filenames[0]) == u"InstallESD.dmg":
             return filenames[0]
     return None
 

--- a/AutoDMG/IEDWorkflow.py
+++ b/AutoDMG/IEDWorkflow.py
@@ -117,12 +117,15 @@ class IEDWorkflow(NSObject):
         if failedUnmounts:
             text = u"\n".join(u"%s: %s" % (dmg, error) for dmg, error in failedUnmounts.iteritems())
             self.delegate.displayAlert_text_(u"Failed to eject dmgs", text)
+        if os.path.basename(self.newSourcePath) == u"InstallESD.dmg":
+            self.installESDPath = self.newSourcePath
+        else:
+            self.installESDPath = os.path.join(self.newSourcePath, u"Contents/SharedSupport/InstallESD.dmg")
         
         self.delegate.examiningSource_(self.newSourcePath)
         
         self.installerMountPoint = None
         self.baseSystemMountedFromPath = None
-        self.installESDPath = os.path.join(self.newSourcePath, u"Contents/SharedSupport/InstallESD.dmg")
         self.dmgHelper.attach_selector_(self.installESDPath, self.handleSourceMountResult_)
     
     # handleSourceMountResult: may be called twice, once for InstallESD.dmg


### PR DESCRIPTION
Decided to just open a new PR because #2 is encumbered with a much older tree.

I also realized I'd overthought the last approach, so now checkSource simply returns whatever file it gets, and IEDWorkflow can sort it out. This also allowed me to remove the ugly code to derive the "correct" icon for the dropped source.
