### PR TITLE
Support for -s/--size CLI build option

### DIFF
--- a/AutoDMG/IEDCLIController.py
+++ b/AutoDMG/IEDCLIController.py
@@ -105,12 +105,7 @@ class IEDCLIController(NSObject):
         if args.name:
             template.setVolumeName_(args.name)
         if args.size:
-            try:
-                template.setVolumeSize_(int(float(args.size)))
-            except ValueError:
-                self.failWithMessage_(u"Invalid -s/--size '%s'; should be a numerical value only, in GB" %
-                                      args.size)
-                return os.EX_DATAERR
+            template.setVolumeSize_(args.size)
         if args.updates is not None:
             template.setApplyUpdates_(True)
         if args.packages:
@@ -247,7 +242,7 @@ class IEDCLIController(NSObject):
         argparser.add_argument(u"-o", u"--output", help=u"DMG output path")
         argparser.add_argument(u"-i", u"--installer", help=u"Override installer in template")
         argparser.add_argument(u"-n", u"--name", help=u"Installed system volume name")
-        argparser.add_argument(u"-s", u"--size", help=u"Installed system volume size, in GB")
+        argparser.add_argument(u"-s", u"--size", type=int, help=u"Installed system volume size, in GB")
         argparser.add_argument(u"-u", u"--updates", action=u"store_const", const=True, help=u"Apply updates")
         argparser.add_argument(u"-U", u"--download-updates", action=u"store_true", help=u"Download missing updates")
         argparser.add_argument(u"-f", u"--force", action=u"store_true", help=u"Overwrite output")

--- a/AutoDMG/IEDCLIController.py
+++ b/AutoDMG/IEDCLIController.py
@@ -104,6 +104,13 @@ class IEDCLIController(NSObject):
             template.setOutputPath_(args.output)
         if args.name:
             template.setVolumeName_(args.name)
+        if args.size:
+            try:
+                template.setVolumeSize_(int(float(args.size)))
+            except ValueError:
+                self.failWithMessage_(u"Invalid -s/--size '%s'; should be a numerical value only, in GB" %
+                                      args.size)
+                return os.EX_DATAERR
         if args.updates is not None:
             template.setApplyUpdates_(True)
         if args.packages:
@@ -240,6 +247,7 @@ class IEDCLIController(NSObject):
         argparser.add_argument(u"-o", u"--output", help=u"DMG output path")
         argparser.add_argument(u"-i", u"--installer", help=u"Override installer in template")
         argparser.add_argument(u"-n", u"--name", help=u"Installed system volume name")
+        argparser.add_argument(u"-s", u"--size", help=u"Installed system volume size, in GB")
         argparser.add_argument(u"-u", u"--updates", action=u"store_const", const=True, help=u"Apply updates")
         argparser.add_argument(u"-U", u"--download-updates", action=u"store_true", help=u"Download missing updates")
         argparser.add_argument(u"-f", u"--force", action=u"store_true", help=u"Overwrite output")


### PR DESCRIPTION
As discussed - this provides a companion option to `-n/--name`, as previously the volume size could only be specified via the use of a template file.

Just basic user input validation done up front - let me know if there's anything else you think would be important to include here. Thanks!