### PR TITLE
Add "Finalize Tasks: Scan for restore" option

### DIFF
--- a/AutoDMG/IEDCLIController.py
+++ b/AutoDMG/IEDCLIController.py
@@ -106,6 +106,8 @@ class IEDCLIController(NSObject):
             template.setVolumeName_(args.name)
         if args.size:
             template.setVolumeSize_(args.size)
+        if args.skip_asr_imagescan:
+            template.setSkipAsrImagescan_(True)
         if args.updates is not None:
             template.setApplyUpdates_(True)
         if args.packages:
@@ -218,6 +220,7 @@ class IEDCLIController(NSObject):
         self.workflow.setOutputPath_(template.outputPath)
         self.workflow.setVolumeName_(template.volumeName)
         self.workflow.setVolumeSize_(template.volumeSize)
+        self.workflow.setSkipAsrImagescan_(template.skipAsrImagescan)
         self.workflow.setTemplate_(template)
         self.workflow.start()
         self.waitBusy()
@@ -243,6 +246,7 @@ class IEDCLIController(NSObject):
         argparser.add_argument(u"-i", u"--installer", help=u"Override installer in template")
         argparser.add_argument(u"-n", u"--name", help=u"Installed system volume name")
         argparser.add_argument(u"-s", u"--size", type=int, help=u"Installed system volume size, in GB")
+        argparser.add_argument(u"--skip-asr-imagescan", action=u"store_true", help=u"Skip `asr imagescan` (Scan for Restore) phase")
         argparser.add_argument(u"-u", u"--updates", action=u"store_const", const=True, help=u"Apply updates")
         argparser.add_argument(u"-U", u"--download-updates", action=u"store_true", help=u"Download missing updates")
         argparser.add_argument(u"-f", u"--force", action=u"store_true", help=u"Overwrite output")

--- a/AutoDMG/IEDCLIController.py
+++ b/AutoDMG/IEDCLIController.py
@@ -107,7 +107,7 @@ class IEDCLIController(NSObject):
         if args.size:
             template.setVolumeSize_(args.size)
         if args.skip_asr_imagescan:
-            template.setSkipAsrImagescan_(True)
+            template.setFinalizeAsrImagescan_(False)
         if args.updates is not None:
             template.setApplyUpdates_(True)
         if args.packages:
@@ -220,7 +220,7 @@ class IEDCLIController(NSObject):
         self.workflow.setOutputPath_(template.outputPath)
         self.workflow.setVolumeName_(template.volumeName)
         self.workflow.setVolumeSize_(template.volumeSize)
-        self.workflow.setSkipAsrImagescan_(template.skipAsrImagescan)
+        self.workflow.setFinalizeAsrImagescan_(template.finalizeAsrImagescan)
         self.workflow.setTemplate_(template)
         self.workflow.start()
         self.waitBusy()

--- a/AutoDMG/IEDController.py
+++ b/AutoDMG/IEDController.py
@@ -40,6 +40,7 @@ class IEDController(NSObject):
     advancedWindow = IBOutlet()
     volumeName = IBOutlet()
     volumeSize = IBOutlet()
+    skipAsrImagescan = IBOutlet()
     
     def awakeFromNib(self):
         LogDebug(u"awakeFromNib")
@@ -254,6 +255,11 @@ class IEDController(NSObject):
         if self.volumeSize.stringValue():
             template.setVolumeSize_(self.volumeSize.intValue())
             self.workflow.setVolumeSize_(self.volumeSize.intValue())
+
+        skip_asr = bool(self.skipAsrImagescan.state())
+        template.setSkipAsrImagescan_(skip_asr)
+        self.workflow.setSkipAsrImagescan_(skip_asr)
+
         self.workflow.setTemplate_(template)
         
         self.workflow.setPackagesToInstall_(self.updateController.packagesToInstall() +

--- a/AutoDMG/IEDController.py
+++ b/AutoDMG/IEDController.py
@@ -416,7 +416,7 @@ class IEDController(NSObject):
             self.volumeSize.setIntValue_(template.volumeSize)
         # Finalize task: ASR imagescan.
         self.finalizeAsrImagescan.setState_(NSOnState)
-        if template.finalizeAsrImagescan :
+        if template.finalizeAsrImagescan == False:
             LogDebug(u"Setting 'Finalize: Scan for restore' to %@", template.finalizeAsrImagescan)
             self.finalizeAsrImagescan.setState_(NSOffState)
         # SourcePath.

--- a/AutoDMG/IEDController.py
+++ b/AutoDMG/IEDController.py
@@ -365,6 +365,8 @@ class IEDController(NSObject):
             template.setVolumeName_(self.volumeName.stringValue())
         if self.volumeSize.intValue():
             template.setVolumeSize_(self.volumeSize.intValue())
+        if self.skipAsrImagescan.state() == NSOnState:
+            template.setSkipAsrImagescan_(True)
         template.setAdditionalPackages_([x.path() for x in self.addPkgController.packagesToInstall()])
         
         error = template.saveTemplateAndReturnError_(url.path())
@@ -412,6 +414,11 @@ class IEDController(NSObject):
         if template.volumeSize:
             LogDebug(u"Setting volume size to %@", template.volumeSize)
             self.volumeSize.setIntValue_(template.volumeSize)
+        # Skip ASR imagescan.
+        self.skipAsrImagescan.setState_(NSOffState)
+        if template.skipAsrImagescan:
+            LogDebug(u"Setting 'Don\'t Scan for Restore' to %@", template.skipAsrImagescan)
+            self.skipAsrImagescan.setState_(NSOnState)
         # SourcePath.
         if template.sourcePath:
             LogDebug(u"Setting source to %@", template.sourcePath)

--- a/AutoDMG/IEDController.py
+++ b/AutoDMG/IEDController.py
@@ -40,7 +40,7 @@ class IEDController(NSObject):
     advancedWindow = IBOutlet()
     volumeName = IBOutlet()
     volumeSize = IBOutlet()
-    skipAsrImagescan = IBOutlet()
+    finalizeAsrImagescan = IBOutlet()
     
     def awakeFromNib(self):
         LogDebug(u"awakeFromNib")
@@ -256,9 +256,9 @@ class IEDController(NSObject):
             template.setVolumeSize_(self.volumeSize.intValue())
             self.workflow.setVolumeSize_(self.volumeSize.intValue())
 
-        skip_asr = bool(self.skipAsrImagescan.state())
-        template.setSkipAsrImagescan_(skip_asr)
-        self.workflow.setSkipAsrImagescan_(skip_asr)
+        finalize_asr_imagescan = bool(self.finalizeAsrImagescan.state())
+        template.setFinalizeAsrImagescan_(finalize_asr_imagescan)
+        self.workflow.setFinalizeAsrImagescan_(finalize_asr_imagescan)
 
         self.workflow.setTemplate_(template)
         
@@ -365,8 +365,8 @@ class IEDController(NSObject):
             template.setVolumeName_(self.volumeName.stringValue())
         if self.volumeSize.intValue():
             template.setVolumeSize_(self.volumeSize.intValue())
-        if self.skipAsrImagescan.state() == NSOnState:
-            template.setSkipAsrImagescan_(True)
+        if self.finalizeAsrImagescan.state() == NSOffState:
+            template.setFinalizeAsrImagescan_(False)
         template.setAdditionalPackages_([x.path() for x in self.addPkgController.packagesToInstall()])
         
         error = template.saveTemplateAndReturnError_(url.path())
@@ -414,11 +414,11 @@ class IEDController(NSObject):
         if template.volumeSize:
             LogDebug(u"Setting volume size to %@", template.volumeSize)
             self.volumeSize.setIntValue_(template.volumeSize)
-        # Skip ASR imagescan.
-        self.skipAsrImagescan.setState_(NSOffState)
-        if template.skipAsrImagescan:
-            LogDebug(u"Setting 'Don\'t Scan for Restore' to %@", template.skipAsrImagescan)
-            self.skipAsrImagescan.setState_(NSOnState)
+        # Finalize task: ASR imagescan.
+        self.finalizeAsrImagescan.setState_(NSOnState)
+        if template.finalizeAsrImagescan :
+            LogDebug(u"Setting 'Finalize: Scan for restore' to %@", template.finalizeAsrImagescan)
+            self.finalizeAsrImagescan.setState_(NSOffState)
         # SourcePath.
         if template.sourcePath:
             LogDebug(u"Setting source to %@", template.sourcePath)

--- a/AutoDMG/IEDTemplate.py
+++ b/AutoDMG/IEDTemplate.py
@@ -46,6 +46,7 @@ class IEDTemplate(NSObject):
                           "    additionalPackages=(%s)" % ", ".join(repr(x) for x in self.additionalPackages),
                           "    volumeName=%s" % repr(self.volumeName),
                           "    volumeSize=%s" % repr(self.volumeSize),
+                          "    skipAsrImagescan=%s" % repr(self.skipAsrImagescan),
                           ">"))
     
     def initWithSourcePath_(self, path):

--- a/AutoDMG/IEDTemplate.py
+++ b/AutoDMG/IEDTemplate.py
@@ -31,6 +31,7 @@ class IEDTemplate(NSObject):
         self.additionalPackageError = None
         self.volumeName = u"Macintosh HD"
         self.volumeSize = None
+        self.skipAsrImagescan = False
         self.packagesToInstall = None
         
         self.loadedTemplates = set()
@@ -68,6 +69,8 @@ class IEDTemplate(NSObject):
             plist[u"OutputPath"] = self.outputPath
         if self.volumeSize:
             plist[u"VolumeSize"] = self.volumeSize
+        if self.skipAsrImagescan:
+            plist[u"SkipAsrImagescan"] = self.skipAsrImagescan
         if plist.writeToFile_atomically_(path, False):
             return None
         else:
@@ -115,6 +118,8 @@ class IEDTemplate(NSObject):
                 self.setVolumeName_(plist[u"VolumeName"])
             elif key == u"VolumeSize":
                 self.setVolumeSize_(plist[u"VolumeSize"])
+            elif key == u"SkipAsrImagescan":
+                self.setSkipAsrImagescan_(plist[u"SkipAsrImagescan"])
             elif key == u"TemplateFormat":
                 pass
             
@@ -163,6 +168,10 @@ class IEDTemplate(NSObject):
         LogInfo(u"Setting volume size to '%d'", size)
         self.volumeSize = size
     
+    def setSkipAsrImagescan_(self, skipAsrImagescan):
+        LogInfo(u"Setting 'Don\'t Scan for Restore to '%@'", skipAsrImagescan)
+        self.skipAsrImagescan = skipAsrImagescan
+
     def resolvePackages(self):
         self.packagesToInstall = list()
         for path in self.additionalPackages:

--- a/AutoDMG/IEDTemplate.py
+++ b/AutoDMG/IEDTemplate.py
@@ -31,7 +31,7 @@ class IEDTemplate(NSObject):
         self.additionalPackageError = None
         self.volumeName = u"Macintosh HD"
         self.volumeSize = None
-        self.skipAsrImagescan = False
+        self.finalizeAsrImagescan = True
         self.packagesToInstall = None
         
         self.loadedTemplates = set()
@@ -46,7 +46,7 @@ class IEDTemplate(NSObject):
                           "    additionalPackages=(%s)" % ", ".join(repr(x) for x in self.additionalPackages),
                           "    volumeName=%s" % repr(self.volumeName),
                           "    volumeSize=%s" % repr(self.volumeSize),
-                          "    skipAsrImagescan=%s" % repr(self.skipAsrImagescan),
+                          "    finalizeAsrImagescan=%s" % repr(self.finalizeAsrImagescan),
                           ">"))
     
     def initWithSourcePath_(self, path):
@@ -70,8 +70,8 @@ class IEDTemplate(NSObject):
             plist[u"OutputPath"] = self.outputPath
         if self.volumeSize:
             plist[u"VolumeSize"] = self.volumeSize
-        if self.skipAsrImagescan:
-            plist[u"SkipAsrImagescan"] = self.skipAsrImagescan
+        if not self.finalizeAsrImagescan:
+            plist[u"FinalizeAsrImagescan"] = self.finalizeAsrImagescan
         if plist.writeToFile_atomically_(path, False):
             return None
         else:
@@ -119,8 +119,8 @@ class IEDTemplate(NSObject):
                 self.setVolumeName_(plist[u"VolumeName"])
             elif key == u"VolumeSize":
                 self.setVolumeSize_(plist[u"VolumeSize"])
-            elif key == u"SkipAsrImagescan":
-                self.setSkipAsrImagescan_(plist[u"SkipAsrImagescan"])
+            elif key == u"FinalizeAsrImagescan":
+                self.setFinalizeAsrImagescan_(plist[u"FinalizeAsrImagescan"])
             elif key == u"TemplateFormat":
                 pass
             
@@ -169,9 +169,9 @@ class IEDTemplate(NSObject):
         LogInfo(u"Setting volume size to '%d'", size)
         self.volumeSize = size
     
-    def setSkipAsrImagescan_(self, skipAsrImagescan):
-        LogInfo(u"Setting 'Don\'t Scan for Restore to '%@'", skipAsrImagescan)
-        self.skipAsrImagescan = skipAsrImagescan
+    def setFinalizeAsrImagescan_(self, finalizeAsrImagescan):
+        LogInfo(u"Setting 'Finalize: Scan for restore to '%@'", finalizeAsrImagescan)
+        self.finalizeAsrImagescan = finalizeAsrImagescan
 
     def resolvePackages(self):
         self.packagesToInstall = list()

--- a/AutoDMG/IEDWorkflow.py
+++ b/AutoDMG/IEDWorkflow.py
@@ -57,6 +57,7 @@ class IEDWorkflow(NSObject):
         self._authPassword = None
         self._volumeSize = None
         self._template = None
+        self._skipAsrImagescan = False
         self.tempDir = None
         self.templatePath = None
         
@@ -289,6 +290,14 @@ class IEDWorkflow(NSObject):
     def setVolumeSize_(self, size):
         self._volumeSize = size
     
+    # Skip ASR imagescan.
+    
+    def skipAsrImagescan(self):
+        return self._skipAsrImagescan
+    
+    def setSkipAsrImagescan_(self, skipAsrImagescan):
+        self._skipAsrImagescan = skipAsrImagescan
+    
     # Template to save in image.
     
     def template(self):
@@ -387,17 +396,18 @@ class IEDWorkflow(NSObject):
             u"method": self.taskInstall,
             u"phases": installerPhases,
         })
-        
-        # Finalize image.
-        self.tasks.append({
-            u"method": self.taskFinalize,
-            u"phases": [
-                {u"title": u"Scanning disk image", u"weight":   2 * 1024 * 1024},
-                {u"title": u"Scanning disk image", u"weight":   1 * 1024 * 1024},
-                {u"title": u"Scanning disk image", u"weight": 150 * 1024 * 1024},
-                {u"title": u"Scanning disk image", u"weight":  17 * 1024 * 1024, u"optional": True},
-            ],
-        })
+
+        # Finalize image. (Skip adding this task if Scan for Restore is skipped)
+        if not self._skipAsrImagescan:
+            self.tasks.append({
+                u"method": self.taskFinalize,
+                u"phases": [
+                    {u"title": u"Scanning disk image", u"weight":   2 * 1024 * 1024},
+                    {u"title": u"Scanning disk image", u"weight":   1 * 1024 * 1024},
+                    {u"title": u"Scanning disk image", u"weight": 150 * 1024 * 1024},
+                    {u"title": u"Scanning disk image", u"weight":  17 * 1024 * 1024, u"optional": True},
+                ],
+            })
         
         # Finish build.
         self.tasks.append({

--- a/AutoDMG/IEDWorkflow.py
+++ b/AutoDMG/IEDWorkflow.py
@@ -57,7 +57,7 @@ class IEDWorkflow(NSObject):
         self._authPassword = None
         self._volumeSize = None
         self._template = None
-        self._skipAsrImagescan = False
+        self._finalizeAsrImagescan = True
         self.tempDir = None
         self.templatePath = None
         
@@ -290,13 +290,13 @@ class IEDWorkflow(NSObject):
     def setVolumeSize_(self, size):
         self._volumeSize = size
     
-    # Skip ASR imagescan.
+    # Finalize task: ASR imagescan.
     
-    def skipAsrImagescan(self):
-        return self._skipAsrImagescan
+    def finalizeAsrImagescan(self):
+        return self._finalizeAsrImagescan
     
-    def setSkipAsrImagescan_(self, skipAsrImagescan):
-        self._skipAsrImagescan = skipAsrImagescan
+    def setFinalizeAsrImagescan_(self, finalizeAsrImagescan):
+        self._finalizeAsrImagescan = finalizeAsrImagescan
     
     # Template to save in image.
     
@@ -397,8 +397,8 @@ class IEDWorkflow(NSObject):
             u"phases": installerPhases,
         })
 
-        # Finalize image. (Skip adding this task if Scan for Restore is skipped)
-        if not self._skipAsrImagescan:
+        # Finalize image. (Skip adding this task if Finalize: Scan for restore is unchecked.)
+        if self._finalizeAsrImagescan:
             self.tasks.append({
                 u"method": self.taskFinalize,
                 u"phases": [

--- a/AutoDMG/en.lproj/MainMenu.xib
+++ b/AutoDMG/en.lproj/MainMenu.xib
@@ -631,6 +631,7 @@
                 <outlet property="buildProgressWindow" destination="Xho-YZ-fRH" id="c89-Hr-l1E"/>
                 <outlet property="logController" destination="Ssv-D7-Tkv" id="Rnb-Ky-1XY"/>
                 <outlet property="mainWindow" destination="GmA-Xb-izQ" id="JNO-Fx-207"/>
+                <outlet property="skipAsrImagescan" destination="h4b-3I-aGw" id="Hyg-Xb-Jp4"/>
                 <outlet property="sourceBox" destination="zyE-7U-hFC" id="zew-uO-2Pr"/>
                 <outlet property="sourceImage" destination="Cmr-I4-xoi" id="Ly3-Qh-J5h"/>
                 <outlet property="sourceLabel" destination="0RU-gN-IOh" id="EzK-O3-MsB"/>
@@ -1141,6 +1142,26 @@ Gw
                         <rect key="frame" x="208" y="22" width="23" height="17"/>
                         <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="GB" id="8uI-Uf-hdQ">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="h4b-3I-aGw">
+                        <rect key="frame" x="159" y="-2" width="18" height="18"/>
+                        <animations/>
+                        <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" inset="2" id="7eW-Be-EqX">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                    </button>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bgt-SK-Cry">
+                        <rect key="frame" x="10" y="-1" width="145" height="17"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="133" id="Ju3-8P-8fc"/>
+                        </constraints>
+                        <animations/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Don't Scan for Restore:" id="lwf-jk-y1I">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/AutoDMG/en.lproj/MainMenu.xib
+++ b/AutoDMG/en.lproj/MainMenu.xib
@@ -629,9 +629,9 @@
                 <outlet property="buildProgressMessage" destination="aFM-jG-IAT" id="Wbv-Ke-9p6"/>
                 <outlet property="buildProgressPhase" destination="PSc-ey-sYw" id="ZoT-hl-E5F"/>
                 <outlet property="buildProgressWindow" destination="Xho-YZ-fRH" id="c89-Hr-l1E"/>
+                <outlet property="finalizeAsrImagescan" destination="k1C-Iu-ziv" id="kZz-7W-cFg"/>
                 <outlet property="logController" destination="Ssv-D7-Tkv" id="Rnb-Ky-1XY"/>
                 <outlet property="mainWindow" destination="GmA-Xb-izQ" id="JNO-Fx-207"/>
-                <outlet property="skipAsrImagescan" destination="h4b-3I-aGw" id="Hyg-Xb-Jp4"/>
                 <outlet property="sourceBox" destination="zyE-7U-hFC" id="zew-uO-2Pr"/>
                 <outlet property="sourceImage" destination="Cmr-I4-xoi" id="Ly3-Qh-J5h"/>
                 <outlet property="sourceLabel" destination="0RU-gN-IOh" id="EzK-O3-MsB"/>
@@ -1084,14 +1084,14 @@ Gw
         <window title="Advanced Options" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="aWy-Vm-Nsh">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="359" height="92"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
+            <rect key="contentRect" x="196" y="240" width="359" height="135"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
             <view key="contentView" id="KLu-Tn-rTn">
-                <rect key="frame" x="0.0" y="0.0" width="359" height="92"/>
+                <rect key="frame" x="0.0" y="0.0" width="359" height="135"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UMy-2X-xww">
-                        <rect key="frame" x="161" y="50" width="178" height="22"/>
+                        <rect key="frame" x="161" y="93" width="178" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="ovm-lb-ufw"/>
                         </constraints>
@@ -1103,7 +1103,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yzh-BO-E7f">
-                        <rect key="frame" x="18" y="52" width="137" height="17"/>
+                        <rect key="frame" x="18" y="95" width="137" height="17"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="133" id="L4P-r2-mU0"/>
                         </constraints>
@@ -1115,7 +1115,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ksE-Rj-GyD">
-                        <rect key="frame" x="161" y="20" width="41" height="22"/>
+                        <rect key="frame" x="161" y="63" width="41" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="41" id="hWr-q1-Vnc"/>
                         </constraints>
@@ -1127,7 +1127,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W5I-yJ-kda">
-                        <rect key="frame" x="18" y="22" width="137" height="17"/>
+                        <rect key="frame" x="18" y="65" width="137" height="17"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="133" id="ObF-9X-u7K"/>
                         </constraints>
@@ -1139,7 +1139,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="U53-bl-HYL">
-                        <rect key="frame" x="208" y="22" width="23" height="17"/>
+                        <rect key="frame" x="208" y="65" width="23" height="17"/>
                         <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="GB" id="8uI-Uf-hdQ">
                             <font key="font" metaFont="system"/>
@@ -1147,43 +1147,50 @@ Gw
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="h4b-3I-aGw">
-                        <rect key="frame" x="159" y="-2" width="18" height="18"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jmc-Jn-MGG">
+                        <rect key="frame" x="18" y="20" width="137" height="17"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="133" id="liv-e1-Yys"/>
+                        </constraints>
                         <animations/>
-                        <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" inset="2" id="7eW-Be-EqX">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Finalize Tasks:" id="pNk-PK-Q07">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button translatesAutoresizingMaskIntoConstraints="NO" id="k1C-Iu-ziv">
+                        <rect key="frame" x="159" y="19" width="182" height="18"/>
+                        <animations/>
+                        <buttonCell key="cell" type="check" title="Scan for restore" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="XT6-FB-qW9">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bgt-SK-Cry">
-                        <rect key="frame" x="10" y="-1" width="145" height="17"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="133" id="Ju3-8P-8fc"/>
-                        </constraints>
-                        <animations/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Don't Scan for Restore:" id="lwf-jk-y1I">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="ksE-Rj-GyD" secondAttribute="bottom" constant="20" id="DJm-Pp-rxd"/>
+                    <constraint firstItem="k1C-Iu-ziv" firstAttribute="leading" secondItem="jmc-Jn-MGG" secondAttribute="trailing" constant="8" id="Bob-0B-Wpn"/>
                     <constraint firstItem="yzh-BO-E7f" firstAttribute="leading" secondItem="KLu-Tn-rTn" secondAttribute="leading" constant="20" id="DVj-Iv-Vao"/>
                     <constraint firstItem="UMy-2X-xww" firstAttribute="top" secondItem="KLu-Tn-rTn" secondAttribute="top" constant="20" id="Evk-Qu-Mv0"/>
                     <constraint firstItem="UMy-2X-xww" firstAttribute="leading" secondItem="yzh-BO-E7f" secondAttribute="trailing" constant="8" id="FNu-UL-Hzr"/>
                     <constraint firstItem="yzh-BO-E7f" firstAttribute="top" secondItem="KLu-Tn-rTn" secondAttribute="top" constant="23" id="GPF-fY-YwZ"/>
+                    <constraint firstItem="jmc-Jn-MGG" firstAttribute="top" secondItem="W5I-yJ-kda" secondAttribute="bottom" constant="28" id="JoP-xg-bQt"/>
                     <constraint firstItem="W5I-yJ-kda" firstAttribute="top" secondItem="yzh-BO-E7f" secondAttribute="bottom" constant="13" id="Of4-w8-7LX"/>
                     <constraint firstItem="W5I-yJ-kda" firstAttribute="leading" secondItem="KLu-Tn-rTn" secondAttribute="leading" constant="20" id="PHz-xn-kDI"/>
-                    <constraint firstAttribute="bottom" secondItem="U53-bl-HYL" secondAttribute="bottom" constant="22" id="SjL-KT-vMu"/>
+                    <constraint firstItem="k1C-Iu-ziv" firstAttribute="top" secondItem="U53-bl-HYL" secondAttribute="bottom" constant="30" id="YLP-Xw-abs"/>
+                    <constraint firstItem="k1C-Iu-ziv" firstAttribute="top" secondItem="ksE-Rj-GyD" secondAttribute="bottom" constant="28" id="as4-Im-ME5"/>
                     <constraint firstItem="U53-bl-HYL" firstAttribute="leading" secondItem="ksE-Rj-GyD" secondAttribute="trailing" constant="8" id="dXR-N7-LIT"/>
+                    <constraint firstAttribute="trailing" secondItem="k1C-Iu-ziv" secondAttribute="trailing" constant="20" id="gVD-fP-Kp9"/>
+                    <constraint firstItem="jmc-Jn-MGG" firstAttribute="leading" secondItem="KLu-Tn-rTn" secondAttribute="leading" constant="20" id="gcv-Vw-86a"/>
                     <constraint firstAttribute="trailing" secondItem="UMy-2X-xww" secondAttribute="trailing" constant="20" id="h3h-5K-TRR"/>
-                    <constraint firstAttribute="bottom" secondItem="W5I-yJ-kda" secondAttribute="bottom" constant="22" id="m0U-01-QCH"/>
+                    <constraint firstAttribute="bottom" secondItem="jmc-Jn-MGG" secondAttribute="bottom" constant="20" id="kb1-SI-AW6"/>
+                    <constraint firstItem="ksE-Rj-GyD" firstAttribute="top" secondItem="UMy-2X-xww" secondAttribute="bottom" constant="8" id="kor-lD-rqI"/>
+                    <constraint firstAttribute="bottom" secondItem="k1C-Iu-ziv" secondAttribute="bottom" constant="21" id="lGn-WV-FJC"/>
                     <constraint firstItem="ksE-Rj-GyD" firstAttribute="leading" secondItem="W5I-yJ-kda" secondAttribute="trailing" constant="8" id="uoV-fu-VXW"/>
                 </constraints>
                 <animations/>
             </view>
+            <point key="canvasLocation" x="437.5" y="420.5"/>
         </window>
     </objects>
     <resources>


### PR DESCRIPTION
This makes it possible to skip the ASR restore phase, as I suggested in #144. This works, although some things aren't yet done:

- [x] CLI option
- [x] Advanced Window is messed up - I have no idea what I'm doing with UI layouts yet
- [x] The `SkipAsrImagescan` template key gets written to the plist in the .adtmpl baked into the image, but if I just do a save within AutoDMG this property isn't saved - in testing this I noticed that `VolumeSize` doesn't seem to either, although `VolumeName` does