### PR TITLE
Fix VolumeSize not being saved to template

### DIFF
--- a/AutoDMG/IEDController.py
+++ b/AutoDMG/IEDController.py
@@ -357,6 +357,8 @@ class IEDController(NSObject):
             template.setApplyUpdates_(False)
         if self.volumeName.stringValue():
             template.setVolumeName_(self.volumeName.stringValue())
+        if self.volumeSize.intValue():
+            template.setVolumeSize_(self.volumeSize.intValue())
         template.setAdditionalPackages_([x.path() for x in self.addPkgController.packagesToInstall()])
         
         error = template.saveTemplateAndReturnError_(url.path())


### PR DESCRIPTION
As mentioned in #145, the `VolumeSize` key wasn't being saved to the template, added this logic next to `saveTemplateToURL_()`. Loading the template and applying the value already worked correctly.