### PR TITLE
Accept OS X system images via CLI build command

### DIFF
--- a/AutoDMG/IEDCLIController.py
+++ b/AutoDMG/IEDCLIController.py
@@ -79,14 +79,15 @@ class IEDCLIController(NSObject):
         
         # Parse arguments.
         
-        sourcePath = IEDUtil.installESDPath_(args.source)
+        sourcePath = IEDUtil.installESDPath_(args.source) or \
+                        IEDUtil.systemImagePath_(args.source)
         if sourcePath:
             templatePath = None
         else:
             templatePath = self.checkTemplate_(args.source)
         
         if not sourcePath and not templatePath:
-            self.failWithMessage_(u"'%s' is not a valid OS X installer or AutoDMG template" % args.source)
+            self.failWithMessage_(u"'%s' is not a valid OS X installer, OS X system image or AutoDMG template" % args.source)
             return os.EX_DATAERR
         
         if templatePath:
@@ -241,7 +242,7 @@ class IEDCLIController(NSObject):
         return path
     
     def addargsBuild_(self, argparser):
-        argparser.add_argument(u"source", help=u"OS X installer or AutoDMG template")
+        argparser.add_argument(u"source", help=u"OS X installer, OS X system image or AutoDMG template")
         argparser.add_argument(u"-o", u"--output", help=u"DMG output path")
         argparser.add_argument(u"-i", u"--installer", help=u"Override installer in template")
         argparser.add_argument(u"-n", u"--name", help=u"Installed system volume name")

--- a/AutoDMG/IEDUtil.py
+++ b/AutoDMG/IEDUtil.py
@@ -73,6 +73,18 @@ class IEDUtil(NSObject):
             return path
         else:
             return None
+
+    @classmethod
+    def systemImagePath_(cls, path):
+        u"""Resolve aliases and return path to a system image."""
+        path = cls.resolvePath_(path)
+        if not path:
+            return None
+        if os.path.basename(path).lower().endswith(u".dmg") and \
+            os.path.exists(path):
+            return path
+        else:
+            return None
     
     @classmethod
     def getPackageSize_(cls, path):


### PR DESCRIPTION
For #147: I went the way of just making a separate validation method similar to `installESDPath_()` in `IEDUtil.py` to check the path naming of the system image, to keep the arg parsing logic in `IEDCLIController.py` simpler.