### PR TITLE
Hotfix/mojave b5 error

### DIFF
--- a/AutoDMG/IEDCLIController.py
+++ b/AutoDMG/IEDCLIController.py
@@ -258,7 +258,7 @@ class IEDCLIController(NSObject):
         argparser.add_argument("-u", "--updates", action="store_const", const=True, help="Apply updates")
         argparser.add_argument("-U", "--download-updates", action="store_true", help="Download missing updates")
         argparser.add_argument("-f", "--force", action="store_true", help="Overwrite output")
-        argparser.add_argument("-F", "--filesystem", choices=["apfs", "hfs"], help="Filesystem for 10.13 images")
+        argparser.add_argument("-F", "--filesystem", choices=["apfs", "hfs"], help="Filesystem for 10.13+ images")
         argparser.add_argument("packages", nargs="*", help="Additional packages")
     
     

--- a/AutoDMG/IEDController.py
+++ b/AutoDMG/IEDController.py
@@ -92,12 +92,9 @@ class IEDController(NSObject):
         if IEDUtil.hostMajorVersion() < 13:
             self.filesystem.selectItem_(self.filesystemHfs)
             self.filesystemApfs.setEnabled_(False)
-        if IEDUtil.hostMajorVersion() == 13:
-            self.filesystem.selectItem_(self.filesystemApfs)
-            self.filesystemApfs.setEnabled_(True)
         else:
             self.filesystem.selectItem_(self.filesystemApfs)
-            self.filesystemHfs.setEnabled_(False)
+            self.filesystemApfs.setEnabled_(True)
     
     # Methods to communicate with app delegate.
     

--- a/AutoDMG/IEDWorkflow.py
+++ b/AutoDMG/IEDWorkflow.py
@@ -333,15 +333,12 @@ class IEDWorkflow(NSObject):
     def setFinalizeAsrImagescan_(self, finalizeAsrImagescan):
         self._finalizeAsrImagescan = finalizeAsrImagescan
     
-    # Filesystem for 10.13 images.
+    # Filesystem for 10.13+ images.
     
     def filesystem(self):
         if IEDUtil.hostMajorVersion() < 13:
             LogDebug("Workflow filesystem is always hfs for this OS version")
             return "hfs"
-        elif IEDUtil.hostMajorVersion() > 13:
-            LogDebug("Workflow filesystem is always apfs for this OS version")
-            return "apfs"
         elif self._filesystem:
             LogDebug("Workflow filesystem is set to '%@'", self._filesystem)
             return self._filesystem
@@ -351,14 +348,6 @@ class IEDWorkflow(NSObject):
     
     def setFilesystem_(self, filesystem):
         LogDebug("Setting filesystem for workflow to '%@'", filesystem)
-        if filesystem == "hfs":
-            if IEDUtil.hostMajorVersion() > 13:
-                LogWarning("Ignoring filesystem setting, only apfs is supported")
-        elif filesystem == "apfs":
-            if IEDUtil.hostMajorVersion() < 13:
-                LogWarning("Ignoring filesystem setting, only hfs is supported")
-        else:
-            LogWarning("Unrecognized filesystem setting '%@'", filesystem)
         self._filesystem = filesystem
     
     # Template to save in image.

--- a/AutoDMG/UpdateProfiles.plist
+++ b/AutoDMG/UpdateProfiles.plist
@@ -129,6 +129,9 @@
 		<key>10.14-18A293u</key>
 		<array>
 		</array>
+		<key>10.14-18A353d</key>
+		<array>
+		</array>
 	</dict>
 	<key>PublicationDate</key>
 	<date>2018-06-06T09:45:21Z</date>

--- a/AutoDMG/installesdtodmg.sh
+++ b/AutoDMG/installesdtodmg.sh
@@ -16,7 +16,6 @@
 #       /tmp/template.adtmpl \
 #       "/Volumes/OS X Install ESD/Packages/OSInstall.mpkg" [package.pkg ...]
 
-touch /Users/test/Desktop/washere.txt 
 
 declare -r TESTING="no"
 

--- a/AutoDMG/installesdtodmg.sh
+++ b/AutoDMG/installesdtodmg.sh
@@ -16,6 +16,7 @@
 #       /tmp/template.adtmpl \
 #       "/Volumes/OS X Install ESD/Packages/OSInstall.mpkg" [package.pkg ...]
 
+touch /Users/test/Desktop/washere.txt 
 
 declare -r TESTING="no"
 
@@ -238,6 +239,10 @@ for package; do
             echo "installer:%100.0"
             sleep 0.25
         else
+            mkdir -p -m 0755 "$sparsemount/private/var/log"
+            chown root:wheel "$sparsemount/private"
+            chown root:wheel "$sparsemount/private/var"
+            chown root:wheel "$sparsemount/private/var/log"
             installer -verboseR -dumplog -pkg "$package" -target "$sparsemount"
             declare -i result=$?
             if [[ $result -ne 0 ]]; then


### PR DESCRIPTION
These commits contain diffs of frogors patched AutoDMG.app which currently works with 10.14 b5 and b6 if the source Install macOS app bundle resides on either an external disk or within a .dmg file.
