### PR TITLE
Updates for Safari, iTunes, Security

### DIFF
--- a/AutoDMG/UpdateProfiles.plist
+++ b/AutoDMG/UpdateProfiles.plist
@@ -59,6 +59,7 @@
 			<string>16G1114</string>
 			<string>16G1212</string>
 			<string>16G1314</string>
+			<string>16G1710</string>
 		</array>
 		<key>10.13.6-17G65</key>
 		<array>
@@ -83,7 +84,7 @@
 			<string>17E199</string>
 			<string>17F77</string>
 		</array>
-		<key>10.14-18A389</key>
+		<key>10.14.4-18E226</key>
 		<array>
 			<string>18A293u</string>
 			<string>18A314h</string>
@@ -95,18 +96,23 @@
 			<string>18A371a</string>
 			<string>18A377a</string>
 			<string>18A384a</string>
+			<string>18A389</string>
+			<string>18A391</string>
+			<string>18B75</string>
+			<string>18C54</string>
+			<string>18D42</string>
 		</array>
 	</dict>
 	<key>DeprecatedOSVersions</key>
 	<array>
 		<string>10.9</string>
 		<string>10.10</string>
+		<string>10.11</string>
 	</array>
 	<key>Profiles</key>
 	<dict>
 		<key>10.10.5-14F2511</key>
-		<array>
-		</array>
+		<array/>
 		<key>10.10.5-14F27</key>
 		<array>
 			<string>RemoteDesktopClient</string>
@@ -114,8 +120,7 @@
 			<string>SafariYo</string>
 		</array>
 		<key>10.11.6-15G21013</key>
-		<array>
-		</array>
+		<array/>
 		<key>10.11.6-15G31</key>
 		<array>
 			<string>CameraRawElCap</string>
@@ -124,26 +129,27 @@
 			<string>AppStoreElCap</string>
 			<string>RemoteDesktopClient</string>
 		</array>
-		<key>10.12.6-16G1408</key>
-		<array>
-		</array>
+		<key>10.12.6-16G1815</key>
+		<array/>
 		<key>10.12.6-16G29</key>
 		<array>
 			<string>RemoteDesktopClient</string>
 			<string>SecuritySierra</string>
 			<string>SafariSierra</string>
 		</array>
+		<key>10.13.6-17G5019</key>
+		<array/>
 		<key>10.13.6-17G65</key>
 		<array>
-			<string>iTunesHighSierra</string>
 			<string>SafariHighSierra</string>
+			<string>SecurityHighSierra</string>
+			<string>iTunesHighSierra</string>
 		</array>
-		<key>10.14-18A389</key>
-		<array>
-		</array>
+		<key>10.14.4-18E226</key>
+		<array/>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2018-09-24T08:46:44Z</date>
+	<date>2019-03-27T12:17:18Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AppStoreElCap</key>
@@ -193,24 +199,24 @@
 		<key>SafariHighSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 12 for High Sierra</string>
+			<string>Safari 12.0.3 for High Sierra</string>
 			<key>sha1</key>
-			<string>4ab8d4212f889b833f23591319e34b941768d274</string>
+			<string>a98689e2d56ef363de54c5c2ed48bfa8edb513c9</string>
 			<key>size</key>
-			<integer>80809321</integer>
+			<integer>80940390</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/51/54/091-77636/pgscon52wejsvoz8nbjanm8qpe0z69v1am/Safari12.0HighSierraAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/55/25/041-25738/iyrwf769xfe9jzsz3p2c0iv45rtw47t0bq/Safari12.0.3HighSierraAuto.pkg</string>
 		</dict>
 		<key>SafariSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 12 for Sierra</string>
+			<string>Safari 12.1 for Sierra</string>
 			<key>sha1</key>
-			<string>7db7f9274cefb8372cf9cbdab4fc572c56f29c4d</string>
+			<string>994a6470874a3ba2a636cf86fc63dfb3da02c6d5</string>
 			<key>size</key>
-			<integer>80645509</integer>
+			<real>81513835</real>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/27/44/091-79545/obipg799hidr41hspkoc5kds6uiy5eikxx/Safari12.0Sierra.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/13/56/041-18158/9eg2q2gxdk1c6yo9h45b4p7yfe12wkm3e8/Safari12.1Sierra.pkg</string>
 		</dict>
 		<key>SafariYo</key>
 		<dict>
@@ -234,16 +240,27 @@
 			<key>url</key>
 			<string>http://updates-http.cdn-apple.com/2018/macos/091-63420-94327-20180709-5409BA12-7C10-11E8-84CF-4F47544C24EB/SecUpd2018-004ElCapitan.dmg</string>
 		</dict>
+		<key>SecurityHighSierra</key>
+		<dict>
+			<key>name</key>
+			<string>Security Update 2019-001 (High Sierra)</string>
+			<key>sha1</key>
+			<string>514f83de702fa5efe281dee3847fd0af9b35c624</string>
+			<key>size</key>
+			<integer>1825550030</integer>
+			<key>url</key>
+			<string>http://updates-http.cdn-apple.com/2019/macos/041-31491-20190122-BBE902D6-D788-11E8-B555-8E91F34A5CAA/SecUpd2019-001HighSierra.dmg</string>
+		</dict>
 		<key>SecuritySierra</key>
 		<dict>
 			<key>name</key>
-			<string>Security Update 2018-004 (Sierra)</string>
+			<string>Security Update 2019-001 (Sierra)</string>
 			<key>sha1</key>
-			<string>9332acabc82146aa85eaf5abfabd9680edfed1a5</string>
+			<string>2b09b80e7ff937cb1d766af8c977ce7895b8dee3</string>
 			<key>size</key>
-			<integer>786586361</integer>
+			<integer>832853744</integer>
 			<key>url</key>
-			<string>http://updates-http.cdn-apple.com/2018/macos/091-65274-94327-20180709-5409BA12-7C10-11E8-84CF-4F47544C24EB/SecUpd2018-004Sierra.dmg</string>
+			<string>http://updates-http.cdn-apple.com/2019/macos/041-31494-20190122-BBE902D6-D788-11E8-B555-8E91F34A5CAA/SecUpd2019-001Sierra.dmg</string>
 		</dict>
 		<key>SecurityYo</key>
 		<dict>
@@ -259,13 +276,13 @@
 		<key>iTunesHighSierra</key>
 		<dict>
 			<key>name</key>
-			<string>iTunes 12.8</string>
+			<string>iTunes 12.8.2</string>
 			<key>sha1</key>
-			<string>c0c82adb920626fc500134732c4de2e0de6ea235</string>
+			<string>77095f6373c2a29b146b1011050871c184d3e0e1</string>
 			<key>size</key>
-			<integer>275915484</integer>
+			<integer>286555253</integer>
 			<key>url</key>
-			<string>https://secure-appldnld.apple.com/itunes12/091-81690-20180709-3C97E2AB-D6CC-4B92-B290-2F21E56F6F70/iTunes12.8.dmg</string>
+			<string>https://secure-appldnld.apple.com/itunes12/041-30445-20190122-BFF2CE0C-FA9C-11E8-A8BB-9B0D7D00924D/iTunes12.8.2.dmg</string>
 		</dict>
 	</dict>
 </dict>

--- a/AutoDMG/UpdateProfiles.plist
+++ b/AutoDMG/UpdateProfiles.plist
@@ -149,7 +149,7 @@
 		<array/>
 	</dict>
 	<key>PublicationDate</key>
-	<date>2019-03-27T12:17:18Z</date>
+	<date>2019-04-11T23:37:43Z</date>
 	<key>Updates</key>
 	<dict>
 		<key>AppStoreElCap</key>
@@ -199,13 +199,13 @@
 		<key>SafariHighSierra</key>
 		<dict>
 			<key>name</key>
-			<string>Safari 12.0.3 for High Sierra</string>
+			<string>Safari 12.1 for High Sierra</string>
 			<key>sha1</key>
-			<string>a98689e2d56ef363de54c5c2ed48bfa8edb513c9</string>
+			<string>f9c0e659f96c05b20ef1b5e51f6020dd1dbd00d6</string>
 			<key>size</key>
-			<integer>80940390</integer>
+			<integer>81726817</integer>
 			<key>url</key>
-			<string>http://swcdn.apple.com/content/downloads/55/25/041-25738/iyrwf769xfe9jzsz3p2c0iv45rtw47t0bq/Safari12.0.3HighSierraAuto.pkg</string>
+			<string>http://swcdn.apple.com/content/downloads/07/08/041-31481/pxxbu55rq2367hecv8s0odj33wcaacir8e/Safari12.1HighSierraAuto.pkg</string>
 		</dict>
 		<key>SafariSierra</key>
 		<dict>


### PR DESCRIPTION
Added:
* Security Update 2019-001 (Sierra)
* Safari 12.1 for High Sierra
* Safari 12.1 for Sierra
* iTunes 12.8.2 (Sierra)

Used [AutoDMGUpdateProfiles](https://github.com/MagerValp/AutoDMGUpdateProfiles) and followed instructions in README.md.

Fixes #230
