### PR TITLE
Fix installing packages on 10.15

### DIFF
--- a/AutoDMG/IEDDMGHelper.py
+++ b/AutoDMG/IEDDMGHelper.py
@@ -147,7 +147,7 @@ class IEDDMGHelper(NSObject):
                     if "mount-point" in partition:
                         deviceId = partition.get("dev-entry", "").rpartition("/")[-1]
                         roles = apfsVolumes.get(deviceId, {}).get("Roles", [])
-                        if roles:
+                        if any(role != 'System' for role in roles):
                             LogDebug("Skipping %@ which has role %@",
                                 partition["mount-point"],
                                 str(roles))

--- a/AutoDMG/IEDDMGHelper.py
+++ b/AutoDMG/IEDDMGHelper.py
@@ -77,7 +77,7 @@ class IEDDMGHelper(NSObject):
                 try:
                     image_path = dmgInfo["image-path"]
                     alias_path = ""
-                    bookmark = CFURLCreateBookmarkDataFromAliasRecord(kCFAllocatorDefault, dmgInfo["image-alias"])
+                    bookmark = CFURLCreateBookmarkDataFromAliasRecord(kCFAllocatorDefault, dmgInfo.get("image-alias", None))
                     if bookmark:
                         url, stale, error = CFURLCreateByResolvingBookmarkData(None, bookmark,
                                                                                kCFBookmarkResolutionWithoutUIMask,

--- a/AutoDMG/installesdtodmg.sh
+++ b/AutoDMG/installesdtodmg.sh
@@ -178,7 +178,7 @@ if [[ -z "$sysimg" ]]; then
         echo "IED:FAILURE:Failed to mount disk image for install, return code $result."
         exit 101
     fi
-    sparsemount=$(egrep '/Volumes/' <<< "$mountoutput" | head -1 | cut -f3)
+    sparsemount=$(egrep '/Volumes/' <<< "$mountoutput" | tail -1 | cut -f3)
     touch "$sparsemount/.workaround-mojave-b4-installer-bug"
     dmgmounts+=( $(egrep 'Apple_(H|AP)FS' <<< "$mountoutput" | awk '{print $1}') )
 else
@@ -191,13 +191,13 @@ else
         echo "IED:FAILURE:Failed to create shadow image for install, return code $result."
         exit 101
     fi
-    targetdev=$(echo "$shadowoutput" | egrep '/Volumes/' | head -1 | awk '{print $1}')
+    targetdev=$(echo "$shadowoutput" | egrep '/Volumes/' | tail -1 | awk '{print $1}')
     echo "IED:MSG:Renaming $targetdev to $volname"
     if ! diskutil rename "$targetdev" "$volname"; then
         echo "IED:FAILURE:Failed to rename install volume."
         exit 101
     fi
-    sparsemount=$(egrep '/Volumes/' <<< "$shadowoutput" | head -1 | cut -f3)
+    sparsemount=$(egrep '/Volumes/' <<< "$shadowoutput" | tail -1 | cut -f3)
     dmgmounts+=( $(egrep 'Apple_(H|AP)FS' <<< "$shadowoutput" | awk '{print $1}') )
     # If we're using a system image as the source, read the version and build
     # numbers before the first install.


### PR DESCRIPTION
When running on 10.15b9 I ran into several problems with installing packages into a system image that all seemed to be related to the default partitioning scheme created by the installer changing.

Mounting the disk image with `hdiutil attach` now gives the following output:

```
/dev/disk2          	GUID_partition_scheme          	
/dev/disk2s1        	EFI                            	
/dev/disk2s2        	Apple_APFS                     	
/dev/disk3          	EF57347C-0000-11AA-AA11-0030654	
/dev/disk3s1        	41504653-0000-11AA-AA11-0030654	/Volumes/Macintosh HD - Data
/dev/disk3s2        	41504653-0000-11AA-AA11-0030654	/Volumes/Preboot
/dev/disk3s3        	41504653-0000-11AA-AA11-0030654	/Volumes/Recovery
/dev/disk3s4        	41504653-0000-11AA-AA11-0030654	/Volumes/VM
/dev/disk3s5        	41504653-0000-11AA-AA11-0030654	/Volumes/Macintosh HD 1
```

The previous logic of `egrep '/Volumes/' | head -1` picked "/Volumes/Macintosh HD - Data", but the path we actually want is "/Volumes/Macintosh HD 1" so I changed it to `tail`.

`hdiutil info -plist` does not include a `image-alias` field for any of the volumes, so `dmgInfo["image-alias"]` was throwing a KeyError and skipping every volume.

All of the volumes within the DMG now have a Role listed (Data, Preboot, Recovery, VM, System for the ones listed above), so hdiutilAttach_() would report no partitions found. We want to install to the partition with the System role, so I made it not exclude partitions with that role.