### PR TITLE
docs: fix simple typo, additonal -> additional

### DIFF
--- a/AutoDMG/IEDAddPkgController.py
+++ b/AutoDMG/IEDAddPkgController.py
@@ -122,7 +122,7 @@ class IEDAddPkgController(NSObject):
             # Don't allow multiple copies.
             if path in self.packagePaths:
                 return NSDragOperationNone
-            # Ensure the file extension is valid for additonal packages.
+            # Ensure the file extension is valid for additional packages.
             name, ext = os.path.splitext(path)
             if ext.lower() not in IEDUtil.PACKAGE_EXTENSIONS:
                 return NSDragOperationNone


### PR DESCRIPTION
There is a small typo in AutoDMG/IEDAddPkgController.py.

Should read `additional` rather than `additonal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md